### PR TITLE
Unused #include <...> deleted.

### DIFF
--- a/inotify_hook.c
+++ b/inotify_hook.c
@@ -1,8 +1,5 @@
-#include <assert.h>
 #include <dlfcn.h>
 #include <errno.h>
-#include <fcntl.h>
-#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -10,7 +7,6 @@
 #include <sys/select.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <sys/wait.h>
 #include <unistd.h>
 
 #include "listen.h"

--- a/listen.c
+++ b/listen.c
@@ -1,12 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
-#include <errno.h>
 #include <string.h>
-#include <netdb.h>
-#include <sys/types.h>
-#include <netinet/in.h>
-#include <sys/socket.h>
 #include <arpa/inet.h>
 #include "jsmn/jsmn.h"
 #include "listen.h"

--- a/read_listen.c
+++ b/read_listen.c
@@ -1,7 +1,5 @@
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
-#include <strings.h>
 #include "listen.h"
 
 int main(int argc, char *argv[]) {


### PR DESCRIPTION
I was wondering if there was a tool to detect unused `#include`s. TL;DR: there basically isn't. But I removed them one at a time and replaced them if they broke `make clean all`. ¯\_(ツ)_/¯ 
